### PR TITLE
Fix order max 19

### DIFF
--- a/backend/src/Repository/CaptainEntityRepository.php
+++ b/backend/src/Repository/CaptainEntityRepository.php
@@ -117,6 +117,7 @@ class CaptainEntityRepository extends ServiceEntityRepository
         $query->leftJoin(CaptainFinancialDuesEntity::class, 'captainFinancialDuesEntity', Join::WITH, 'captainFinancialDuesEntity.captain = captainEntity.id');
 
         $query->orderBy('captainEntity.id', 'DESC');
+        $query->groupBy('captainEntity.id');
 
         return $query->getQuery()->getResult();
     }

--- a/backend/src/Response/Admin/CaptainFinancialSystem/AdminCaptainFinancialSystemAccordingToCountOfOrdersBalanceDetailResponse.php
+++ b/backend/src/Response/Admin/CaptainFinancialSystem/AdminCaptainFinancialSystemAccordingToCountOfOrdersBalanceDetailResponse.php
@@ -31,4 +31,6 @@ class AdminCaptainFinancialSystemAccordingToCountOfOrdersBalanceDetailResponse
     public array $orders;
 
     public string|null $dateFinancialCycleStarts;
+  
+    public int $countOrdersMaxFromNineteen;
 }

--- a/backend/src/Response/CaptainFinancialSystem/CaptainFinancialSystemAccordingToCountOfOrdersBalanceDetailResponse.php
+++ b/backend/src/Response/CaptainFinancialSystem/CaptainFinancialSystemAccordingToCountOfOrdersBalanceDetailResponse.php
@@ -31,4 +31,6 @@ class CaptainFinancialSystemAccordingToCountOfOrdersBalanceDetailResponse
     public int|null $countOrdersInMonth;
   
     public string|null $dateFinancialCycleStarts;
+
+    public int $countOrdersMaxFromNineteen;
 }

--- a/backend/src/Service/Admin/CaptainFinancialSystem/AdminCaptainFinancialSystemOneBalanceDetailService.php
+++ b/backend/src/Service/Admin/CaptainFinancialSystem/AdminCaptainFinancialSystemOneBalanceDetailService.php
@@ -32,7 +32,7 @@ class AdminCaptainFinancialSystemOneBalanceDetailService
         $orders = $this->adminCaptainFinancialSystemOneBalanceDetailManager->getOrdersByCaptainIdOnSpecificDate($captainId, $date['fromDate'], $date['toDate']);
 
         foreach($detailsOrders as $detailOrder) {
-           if($detailOrder['kilometer'] > CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
+           if($detailOrder['kilometer'] >= CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
                 $countOrdersMaxFromNineteen = $countOrdersMaxFromNineteen + 1;
            }
           

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOneBalanceDetailService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOneBalanceDetailService.php
@@ -32,7 +32,7 @@ class CaptainFinancialSystemOneBalanceDetailService
         $detailsOrders = $this->captainFinancialSystemOneBalanceDetailManager->getDetailOrdersByCaptainIdOnSpecificDate($captainId, $date['fromDate'], $date['toDate']);
 
         foreach($detailsOrders as $detailOrder) {
-           if($detailOrder['kilometer'] > CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
+           if($detailOrder['kilometer'] >= CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
                 $countOrdersMaxFromNineteen = $countOrdersMaxFromNineteen + 1;
            }
 
@@ -81,7 +81,7 @@ class CaptainFinancialSystemOneBalanceDetailService
         $detailsOrders = $this->captainFinancialSystemOneBalanceDetailManager->getDetailOrdersByCaptainIdOnSpecificDate($captainId, $date['fromDate'], $date['toDate']);
 
         foreach($detailsOrders as $detailOrder) {
-           if($detailOrder['kilometer'] > CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
+           if($detailOrder['kilometer'] >= CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
                 $countOrdersMaxFromNineteen = $countOrdersMaxFromNineteen + 1;
            }
 

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemTwoBalanceDetailService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemTwoBalanceDetailService.php
@@ -49,9 +49,21 @@ class CaptainFinancialSystemTwoBalanceDetailService
         $item['sumPayments'] = $sumPayments;
         //The amount received by the captain in cash from the orders, this amount will be handed over to the admin
         $item['amountForStore'] = 0;
-      
-        $checkTarget = $this->checkTarget($financialSystemDetail['countOrdersInMonth'], $countWorkdays, $countOrders);
+        $item['countOrdersMaxFromNineteen'] = 0;
+        
+        foreach($detailsOrders as $orderDetail) {
+            if($orderDetail['kilometer'] >= CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
+                $item['countOrdersMaxFromNineteen'] = $item['countOrdersMaxFromNineteen'] + 1;
+            }
+            if($orderDetail['payment'] === OrderTypeConstant::ORDER_PAYMENT_CASH && $orderDetail['paidToProvider'] === OrderTypeConstant::ORDER_PAID_TO_PROVIDER_NO) {
+                $item['amountForStore'] += $orderDetail['captainOrderCost'];
+            }
+        }
 
+        $item['countOrdersCompleted'] +=  $item['countOrdersMaxFromNineteen'];
+
+        $checkTarget = $this->checkTarget($financialSystemDetail['countOrdersInMonth'], $countWorkdays, $item['countOrdersCompleted']);
+     
         if($checkTarget === CaptainFinancialSystem::TARGET_SUCCESS_INT) {
             $item['salary'] = $financialSystemDetail['salary'];
            
@@ -65,7 +77,7 @@ class CaptainFinancialSystemTwoBalanceDetailService
                 $item['financialDues'] = $item['salary'] + $item['monthCompensation']; 
             }
             else {
-                $item['financialDues'] = $countOrders * CaptainFinancialSystem::TARGET_FAILED_SALARY;  
+                $item['financialDues'] = $item['countOrdersCompleted'] * CaptainFinancialSystem::TARGET_FAILED_SALARY;  
             }
 
             $total = $item['financialDues'] - $sumPayments;
@@ -77,7 +89,7 @@ class CaptainFinancialSystemTwoBalanceDetailService
             $item['monthCompensation'] = $financialSystemDetail['monthCompensation'];
 
             $item['countOrdersInMonth'] = $financialSystemDetail['countOrdersInMonth'];
-            $item['countOverOrdersThanRequired'] = $countOrders - $financialSystemDetail['countOrdersInMonth'] / 30;
+            $item['countOverOrdersThanRequired'] = $item['countOrdersCompleted'] - $financialSystemDetail['countOrdersInMonth'] / 30;
 
             $item['bounce'] = round($item['countOverOrdersThanRequired'] * $financialSystemDetail['bounceMaxCountOrdersInMonth'], 2);   
 
@@ -87,7 +99,7 @@ class CaptainFinancialSystemTwoBalanceDetailService
                 $item['financialDues'] = round($item['salary'] + $item['monthCompensation'] + $item['bounce'], 2); 
             }
             else {
-                $item['financialDues'] = round(($countOrders - $item['countOverOrdersThanRequired']) * CaptainFinancialSystem::TARGET_FAILED_SALARY + $item['bounce'], 2);  
+                $item['financialDues'] = round(( $item['countOrdersCompleted'] - $item['countOverOrdersThanRequired']) * CaptainFinancialSystem::TARGET_FAILED_SALARY + $item['bounce'], 2);  
             }
 
             $total = $item['financialDues'] - $sumPayments;
@@ -102,7 +114,7 @@ class CaptainFinancialSystemTwoBalanceDetailService
              
             $item['countOrdersInMonth'] = $financialSystemDetail['countOrdersInMonth'];
 
-            $item['financialDues'] = $countOrders * CaptainFinancialSystem::TARGET_FAILED_SALARY; 
+            $item['financialDues'] = $item['countOrdersCompleted'] * CaptainFinancialSystem::TARGET_FAILED_SALARY; 
           
             $total = round($item['financialDues'] - $sumPayments, 2);
         }
@@ -114,13 +126,6 @@ class CaptainFinancialSystemTwoBalanceDetailService
         }
 
         $item['total'] = abs($total);
-       
-        foreach($detailsOrders as $orderDetail) {
-            
-            if($orderDetail['payment'] === OrderTypeConstant::ORDER_PAYMENT_CASH && $orderDetail['paidToProvider'] === OrderTypeConstant::ORDER_PAID_TO_PROVIDER_NO) {
-                $item['amountForStore'] += $orderDetail['captainOrderCost'];
-            }
-        }
 
         return $item;
     }
@@ -143,8 +148,21 @@ class CaptainFinancialSystemTwoBalanceDetailService
        $item['financialDues'] = 0;
        //The amount received by the captain in cash from the orders, this amount will be handed over to the admin
        $item['amountForStore'] = 0;
+       $item['countOrdersMaxFromNineteen'] = 0;
+       $item['countOrdersCompleted'] = $countOrders;
 
-       $checkTarget = $this->checkTarget($financialSystemDetail['countOrdersInMonth'], $countWorkdays, $countOrders);
+       foreach($detailsOrders as $orderDetail) {
+            if($orderDetail['kilometer'] >= CaptainFinancialSystem::KILOMETER_TO_DOUBLE_ORDER ) {
+                $item['countOrdersMaxFromNineteen'] = $item['countOrdersMaxFromNineteen'] + 1;
+            }
+            if($orderDetail['payment'] === OrderTypeConstant::ORDER_PAYMENT_CASH && $orderDetail['paidToProvider'] === OrderTypeConstant::ORDER_PAID_TO_PROVIDER_NO) {
+                $item['amountForStore'] += $orderDetail['captainOrderCost'];
+            }
+       }
+
+       $item['countOrdersCompleted'] +=  $item['countOrdersMaxFromNineteen'];
+
+       $checkTarget = $this->checkTarget($financialSystemDetail['countOrdersInMonth'], $countWorkdays, $item['countOrdersCompleted']);
 
        if($checkTarget === CaptainFinancialSystem::TARGET_SUCCESS_INT) {
            $item['salary'] = $financialSystemDetail['salary'];
@@ -153,7 +171,7 @@ class CaptainFinancialSystemTwoBalanceDetailService
               $item['financialDues'] = $financialSystemDetail['salary'] + $financialSystemDetail['monthCompensation']; 
            }
            else {
-              $item['financialDues'] = $countOrders * CaptainFinancialSystem::TARGET_FAILED_SALARY;  
+              $item['financialDues'] = $item['countOrdersCompleted'] * CaptainFinancialSystem::TARGET_FAILED_SALARY;  
             }
         }
        
@@ -162,7 +180,7 @@ class CaptainFinancialSystemTwoBalanceDetailService
             
             $item['monthCompensation'] = $financialSystemDetail['monthCompensation'];
 
-            $item['countOverOrdersThanRequired'] = $countOrders - $financialSystemDetail['countOrdersInMonth'] / 30;
+            $item['countOverOrdersThanRequired'] = $item['countOrdersCompleted'] - $financialSystemDetail['countOrdersInMonth'] / 30;
 
             $item['bounce'] = $item['countOverOrdersThanRequired'] * $financialSystemDetail['bounceMaxCountOrdersInMonth'];   
         
@@ -172,19 +190,12 @@ class CaptainFinancialSystemTwoBalanceDetailService
                  $item['financialDues'] = $item['salary'] + $item['monthCompensation'] + $item['bounce']; 
             }
             else {
-                $item['financialDues'] = ($countOrders - $item['countOverOrdersThanRequired']) * CaptainFinancialSystem::TARGET_FAILED_SALARY + $item['bounce'];  
+                $item['financialDues'] = ($item['countOrdersCompleted'] - $item['countOverOrdersThanRequired']) * CaptainFinancialSystem::TARGET_FAILED_SALARY + $item['bounce'];  
             }
         }
 
        if($checkTarget === CaptainFinancialSystem::TARGET_FAILED_INT) {
-           $item['financialDues'] = $countOrders * CaptainFinancialSystem::TARGET_FAILED_SALARY;          
-       }
-      
-       foreach($detailsOrders as $orderDetail) {
-           
-           if($orderDetail['payment'] === OrderTypeConstant::ORDER_PAYMENT_CASH && $orderDetail['paidToProvider'] === OrderTypeConstant::ORDER_PAID_TO_PROVIDER_NO) {
-               $item['amountForStore'] += $orderDetail['captainOrderCost'];
-           }
+           $item['financialDues'] = $item['countOrdersCompleted'] * CaptainFinancialSystem::TARGET_FAILED_SALARY;          
        }
 
        return $item;


### PR DESCRIPTION
- Removing the duplicate captain from (captainsprofilesbystatus)
- The number of orders is greater and equal to 19 in the second system and first