### PR TITLE
Prevent assigning the order to a captain by condition

### DIFF
--- a/backend/src/Constant/Order/OrderResultConstant.php
+++ b/backend/src/Constant/Order/OrderResultConstant.php
@@ -41,4 +41,6 @@ final class OrderResultConstant
     const CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE = "the captain has received an order for a specific store";
 
     const CREATE_DATE_IS_GREATER_THAN_DELIVERY_DATE = "create time is greater than delivery time";
+
+    const CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT_FOR_ADMIN = 2;
 }

--- a/backend/src/Controller/Admin/Order/AdminOrderController.php
+++ b/backend/src/Controller/Admin/Order/AdminOrderController.php
@@ -725,6 +725,10 @@ class AdminOrderController extends BaseController
             return $this->response(MainErrorConstant::ERROR_MSG, self::CAPTAIN_PROFILE_NOT_EXIST);
         }
 
+        if ($response === OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT_FOR_ADMIN) {
+            return $this->response(MainErrorConstant::ERROR_MSG, self::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE);
+        }
+
         return $this->response($response, self::UPDATE);
     }
 

--- a/backend/src/Manager/Admin/Order/AdminOrderManager.php
+++ b/backend/src/Manager/Admin/Order/AdminOrderManager.php
@@ -309,4 +309,9 @@ class AdminOrderManager
     {
         return $this->orderEntityRepository->filterOrdersNotAnsweredByTheStore($request);
     }
+
+    public function checkWhetherCaptainReceivedOrderForSpecificStore(int $captainProfileId, int $storeId, int|null $orderId): ?OrderEntity
+    {
+        return $this->orderEntityRepository->checkWhetherCaptainReceivedOrderForSpecificStoreForAdmin($captainProfileId, $storeId, $orderId);
+    }
 }

--- a/backend/src/Manager/Admin/Order/AdminOrderManager.php
+++ b/backend/src/Manager/Admin/Order/AdminOrderManager.php
@@ -310,8 +310,8 @@ class AdminOrderManager
         return $this->orderEntityRepository->filterOrdersNotAnsweredByTheStore($request);
     }
 
-    public function checkWhetherCaptainReceivedOrderForSpecificStore(int $captainProfileId, int $storeId, int|null $orderId): ?OrderEntity
+    public function checkWhetherCaptainReceivedOrderForSpecificStore(int $captainProfileId, int $storeId): ?OrderEntity
     {
-        return $this->orderEntityRepository->checkWhetherCaptainReceivedOrderForSpecificStoreForAdmin($captainProfileId, $storeId, $orderId);
+        return $this->orderEntityRepository->checkWhetherCaptainReceivedOrderForSpecificStoreForAdmin($captainProfileId, $storeId);
     }
 }

--- a/backend/src/Repository/OrderEntityRepository.php
+++ b/backend/src/Repository/OrderEntityRepository.php
@@ -2187,4 +2187,24 @@ class OrderEntityRepository extends ServiceEntityRepository
 
         return $query->getQuery()->getResult();
     }
+    
+    public function checkWhetherCaptainReceivedOrderForSpecificStoreForAdmin(int $captainProfileId, int $storeId, int|null $orderId): ?OrderEntity
+    {
+        return $this->createQueryBuilder('orderEntity')
+            ->andWhere('orderEntity.state IN (:statesArray)')
+            ->setParameter('statesArray', OrderStateConstant::ORDER_STATE_ONGOING_FILTER_ARRAY)
+
+            ->andWhere('orderEntity.captainId = :captainId')
+            ->setParameter('captainId', $captainProfileId)
+
+            ->andWhere('orderEntity.storeOwner = :storeId')
+            ->setParameter('storeId', $storeId)
+
+            ->andWhere('orderEntity.id != :id')
+            ->setParameter('id', $orderId)
+
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/backend/src/Repository/OrderEntityRepository.php
+++ b/backend/src/Repository/OrderEntityRepository.php
@@ -2188,7 +2188,7 @@ class OrderEntityRepository extends ServiceEntityRepository
         return $query->getQuery()->getResult();
     }
     
-    public function checkWhetherCaptainReceivedOrderForSpecificStoreForAdmin(int $captainProfileId, int $storeId, int|null $orderId): ?OrderEntity
+    public function checkWhetherCaptainReceivedOrderForSpecificStoreForAdmin(int $captainProfileId, int $storeId): ?OrderEntity
     {
         return $this->createQueryBuilder('orderEntity')
             ->andWhere('orderEntity.state IN (:statesArray)')
@@ -2199,9 +2199,6 @@ class OrderEntityRepository extends ServiceEntityRepository
 
             ->andWhere('orderEntity.storeOwner = :storeId')
             ->setParameter('storeId', $storeId)
-
-            ->andWhere('orderEntity.id != :id')
-            ->setParameter('id', $orderId)
 
             ->setMaxResults(1)
             ->getQuery()

--- a/backend/src/Service/Admin/Order/AdminOrderService.php
+++ b/backend/src/Service/Admin/Order/AdminOrderService.php
@@ -513,7 +513,7 @@ class AdminOrderService
             }
 
             // Check whether the captain has received an order for a specific store
-            $checkCaptainReceivedOrder = $this->checkWhetherCaptainReceivedOrderForSpecificStore($request->getId(), $orderEntity->getStoreOwner()->getId(), $orderEntity->getId(), $orderEntity->getPrimaryOrder()?->getId());
+            $checkCaptainReceivedOrder = $this->checkWhetherCaptainReceivedOrderForSpecificStore($request->getId(), $orderEntity->getStoreOwner()->getId(), $orderEntity->getPrimaryOrder()?->getId());
             if ($checkCaptainReceivedOrder === OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT) {
                 return OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT_FOR_ADMIN;
             }
@@ -851,9 +851,10 @@ class AdminOrderService
         return $response;
     }
 
-    public function checkWhetherCaptainReceivedOrderForSpecificStore(int $captainProfileId, int $storeId, int $orderId, int|null $primaryOrderId): int
+    public function checkWhetherCaptainReceivedOrderForSpecificStore(int $captainProfileId, int $storeId, int|null $primaryOrderId): int
     {
-        $orderEntity = $this->adminOrderManager->checkWhetherCaptainReceivedOrderForSpecificStore($captainProfileId, $storeId, $orderId);
+        $orderEntity = $this->adminOrderManager->checkWhetherCaptainReceivedOrderForSpecificStore($captainProfileId, $storeId);
+       
         if (!empty($orderEntity)) {
             //if the order not main
             if ($orderEntity->getOrderIsMain() !== true) {

--- a/backend/src/Service/Admin/Order/AdminOrderService.php
+++ b/backend/src/Service/Admin/Order/AdminOrderService.php
@@ -855,7 +855,7 @@ class AdminOrderService
     {
         $orderEntity = $this->adminOrderManager->checkWhetherCaptainReceivedOrderForSpecificStore($captainProfileId, $storeId);
        
-        if (!empty($orderEntity)) {
+        if ($orderEntity) {
             //if the order not main
             if ($orderEntity->getOrderIsMain() !== true) {
                 return OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT;

--- a/backend/src/Service/Admin/Order/AdminOrderService.php
+++ b/backend/src/Service/Admin/Order/AdminOrderService.php
@@ -507,10 +507,18 @@ class AdminOrderService
     {
         $orderEntity = $this->adminOrderManager->getOrderById($request->getOrderId());
         if ($orderEntity) {
+            //Check the order if it is pending
             if($orderEntity->getState() !==  OrderStateConstant::ORDER_STATE_PENDING) {
                 return OrderStateConstant::ORDER_STATE_PENDING_INT;
             }
 
+            // Check whether the captain has received an order for a specific store
+            $checkCaptainReceivedOrder = $this->checkWhetherCaptainReceivedOrderForSpecificStore($request->getId(), $orderEntity->getStoreOwner()->getId(), $orderEntity->getId(), $orderEntity->getPrimaryOrder()?->getId());
+            if ($checkCaptainReceivedOrder === OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT) {
+                return OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT_FOR_ADMIN;
+            }
+
+            //Check availability of cars for the store
             $checkRemainingCars = $this->subscriptionService->checkRemainingCarsByOrderId($request->getOrderId());
 
             if ($checkRemainingCars === SubscriptionConstant::CARS_FINISHED) {
@@ -842,5 +850,24 @@ class AdminOrderService
 
         return $response;
     }
-    
+
+    public function checkWhetherCaptainReceivedOrderForSpecificStore(int $captainProfileId, int $storeId, int $orderId, int|null $primaryOrderId): int
+    {
+        $orderEntity = $this->adminOrderManager->checkWhetherCaptainReceivedOrderForSpecificStore($captainProfileId, $storeId, $orderId);
+        if (!empty($orderEntity)) {
+            //if the order not main
+            if ($orderEntity->getOrderIsMain() !== true) {
+                return OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT;
+            }
+            //if the order main and (request order) related
+            if ($primaryOrderId === $orderEntity->getId()) {
+
+                return OrderResultConstant::CAPTAIN_NOT_RECEIVED_ORDER_FOR_THIS_STORE_INT;
+            }
+            //if the order main and (request order) not related
+            return OrderResultConstant::CAPTAIN_RECEIVED_ORDER_FOR_THIS_STORE_INT;
+        }
+
+        return OrderResultConstant::CAPTAIN_NOT_RECEIVED_ORDER_FOR_THIS_STORE_INT;
+    }    
 }


### PR DESCRIPTION
- Prevent assigning the order to a captain if the previous order from the same store is still in progress.