### PR TITLE
subscriptionswithpayment/{storeId} API response had been updated

### DIFF
--- a/backend/src/Controller/Admin/StoreOwnerSubscription/AdminStoreSubscriptionController.php
+++ b/backend/src/Controller/Admin/StoreOwnerSubscription/AdminStoreSubscriptionController.php
@@ -65,7 +65,16 @@ class AdminStoreSubscriptionController extends BaseController
      *          @OA\Property(type="string", property="status_code"),
      *          @OA\Property(type="string", property="msg"),
      *          @OA\Property(type="object", property="Data",
-     *             ref=@Model(type="App\Response\Admin\StoreOwnerSubscription\AdminStoreSubscriptionResponse"),
+     *              @OA\Property(type="array", property="oldSubscriptions",
+     *                  @OA\Items(
+     *                      ref=@Model(type="App\Response\Admin\StoreOwnerSubscription\AdminStoreSubscriptionResponse")
+     *                  )
+     *              ),
+     *              @OA\Property(type="array", property="currentAndFutureSubscriptions",
+     *                  @OA\Items(
+     *                      ref=@Model(type="App\Response\Admin\StoreOwnerSubscription\AdminStoreSubscriptionResponse")
+     *                  )
+     *              )
      *      )
      *    )
      *  )

--- a/backend/src/Service/Admin/StoreOwnerSubscription/AdminStoreSubscriptionService.php
+++ b/backend/src/Service/Admin/StoreOwnerSubscription/AdminStoreSubscriptionService.php
@@ -86,7 +86,12 @@ class AdminStoreSubscriptionService
                 $subscription['total'] = $this->getTotal($subscription['paymentsFromStore'], $subscription['packageCost'], $subscription['captainOffers'],(float)$subscription['packageExtraCost'], $totalExtraDistance);
             }
 
-            $response[] = $this->autoMapping->map("array", AdminStoreSubscriptionResponse::class, $subscription);
+            if (($subscription['isCurrent'] === 0) && ($subscription['isFuture'] === false) && (! $subscription['subscriptionDetailsId'])) {
+                $response['oldSubscriptions'][] = $this->autoMapping->map("array", AdminStoreSubscriptionResponse::class, $subscription);
+
+            } else {
+                $response['currentAndFutureSubscriptions'][] = $this->autoMapping->map("array", AdminStoreSubscriptionResponse::class, $subscription);
+            }
         }
 
         return $response;


### PR DESCRIPTION
- subscriptionswithpayment/{storeId} API response had been updated.