### PR TITLE
Be captain daily financial amount for first and second systems

### DIFF
--- a/backend/src/Constant/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemOneWorkDayConstant.php
+++ b/backend/src/Constant/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemOneWorkDayConstant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Constant\CaptainFinancialSystem\CaptainFinancialSystemOne;
+
+final class CaptainFinancialSystemOneWorkDayConstant
+{
+    const ZERO_WORK_DAY_COUNT_CONST = 0;
+}

--- a/backend/src/Manager/StoreOwnerDuesFromCashOrders/StoreOwnerDuesFromCashOrdersManager.php
+++ b/backend/src/Manager/StoreOwnerDuesFromCashOrders/StoreOwnerDuesFromCashOrdersManager.php
@@ -48,7 +48,9 @@ class StoreOwnerDuesFromCashOrdersManager
         return $this->storeOwnerDuesFromCashOrdersEntityRepository->getStoreOwnerDuesFromCashOrdersByStoreOwnerId($storeOwnerId);
     }
 
-    // Get the dues of unpaid cash orders (for group of orders)
+    /**
+     * Get the sum of unpaid cash and delivered orders amount (for store) by specific captain and among specific date
+     */
     public function getUnPaidCashOrdersDuesByCaptainAndDuringSpecificTime(int $captainId, string $fromDate, string $toDate): array
     {
         return $this->storeOwnerDuesFromCashOrdersEntityRepository->getUnPaidCashOrdersDuesByCaptainAndDuringSpecificTime($captainId, $fromDate, $toDate);

--- a/backend/src/Repository/StoreOwnerDuesFromCashOrdersEntityRepository.php
+++ b/backend/src/Repository/StoreOwnerDuesFromCashOrdersEntityRepository.php
@@ -122,7 +122,9 @@ class StoreOwnerDuesFromCashOrdersEntityRepository extends ServiceEntityReposito
             ->getResult();
     }
 
-    // Get the dues of unpaid cash orders (for group of orders)
+    /**
+     * Get the sum of unpaid cash and delivered orders amount (for store) by specific captain and among specific date
+     */
     public function getUnPaidCashOrdersDuesByCaptainAndDuringSpecificTime(int $captainId, string $fromDate, string $toDate): array
     {
         return $this->createQueryBuilder('storeOwnerDuesFromCashOrdersEntity')

--- a/backend/src/Response/OrderLog/OrderLogCaptainProfileUpdateResponse.php
+++ b/backend/src/Response/OrderLog/OrderLogCaptainProfileUpdateResponse.php
@@ -45,5 +45,8 @@ class OrderLogCaptainProfileUpdateResponse
      */
     public $isCashPaymentConfirmedByStore;
 
-    public array $details = [];
+    /**
+     * @var array|null
+     */
+    public $details;
 }

--- a/backend/src/Response/Subscription/CanCreateOrderResponse.php
+++ b/backend/src/Response/Subscription/CanCreateOrderResponse.php
@@ -4,11 +4,28 @@ namespace App\Response\Subscription;
 
 class CanCreateOrderResponse
 {
-    public bool|null $canCreateOrder;
-   
-    public string|null $subscriptionStatus;
-  
-    public string|null $percentageOfOrdersConsumed;
-    
-    public string|null $packageName;
+    /**
+     * @var bool|null
+     */
+    public $canCreateOrder;
+
+    /**
+     * @var string|null
+     */
+    public $subscriptionStatus;
+
+    /**
+     * @var string|null
+     */
+    public $percentageOfOrdersConsumed;
+
+    /**
+     * @var string|null
+     */
+    public $packageName;
+
+    /**
+     * @var int|null
+     */
+    public $packageType;
 }

--- a/backend/src/Response/Subscription/RemainingOrdersResponse.php
+++ b/backend/src/Response/Subscription/RemainingOrdersResponse.php
@@ -68,4 +68,9 @@ class RemainingOrdersResponse
 
     // The sum of unpaid cash orders
     public float $unPaidCashOrdersSum;
+
+    /**
+     * @var int|null
+     */
+    public $packageType;
 }

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialDailyService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialDailyService.php
@@ -31,7 +31,8 @@ class CaptainFinancialDailyService
         private CaptainFinancialSystemDetailGetService $captainFinancialSystemDetailGetService,
         private DateFactoryService $dateFactoryService,
         private CaptainFinancialDailyManager $captainFinancialDailyManager,
-        private CaptainFinancialSystemThreeDailyService $captainFinancialSystemThreeDailyService
+        private CaptainFinancialSystemThreeDailyService $captainFinancialSystemThreeDailyService,
+        private CaptainFinancialSystemOneDailyService $captainFinancialSystemOneDailyService
     )
     {
     }
@@ -66,9 +67,8 @@ class CaptainFinancialDailyService
 
         if ($captainFinancialSystemDetail['captainFinancialSystemType'] === CaptainFinancialSystem::CAPTAIN_FINANCIAL_SYSTEM_ONE) {
             // Captain financial system is the first one
-            ///todo calculate the order cost according to the first financial system
-
-            return $response;
+            return $this->captainFinancialSystemOneDailyService->getDailyCaptainFinancialAmount($captainFinancialSystemDetail,
+                $captainProfileId, $fromDate, $toDate);
 
         } elseif ($captainFinancialSystemDetail['captainFinancialSystemType'] === CaptainFinancialSystem::CAPTAIN_FINANCIAL_SYSTEM_TWO) {
             // Captain financial system is the second one

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialDailyService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialDailyService.php
@@ -32,7 +32,8 @@ class CaptainFinancialDailyService
         private DateFactoryService $dateFactoryService,
         private CaptainFinancialDailyManager $captainFinancialDailyManager,
         private CaptainFinancialSystemThreeDailyService $captainFinancialSystemThreeDailyService,
-        private CaptainFinancialSystemOneDailyService $captainFinancialSystemOneDailyService
+        private CaptainFinancialSystemOneDailyService $captainFinancialSystemOneDailyService,
+        private CaptainFinancialSystemTwoDailyService $captainFinancialSystemTwoDailyService
     )
     {
     }
@@ -72,9 +73,8 @@ class CaptainFinancialDailyService
 
         } elseif ($captainFinancialSystemDetail['captainFinancialSystemType'] === CaptainFinancialSystem::CAPTAIN_FINANCIAL_SYSTEM_TWO) {
             // Captain financial system is the second one
-            ///todo calculate the order cost according to the second financial system
-
-            return $response;
+            return $this->captainFinancialSystemTwoDailyService->getDailyCaptainFinancialAmount($captainFinancialSystemDetail,
+                $captainProfileId, $fromDate, $toDate);
 
         } elseif ($captainFinancialSystemDetail['captainFinancialSystemType'] === CaptainFinancialSystem::CAPTAIN_FINANCIAL_SYSTEM_THREE) {
             // Captain financial system is the third one

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialSystemOneDailyService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialSystemOneDailyService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Service\CaptainFinancialSystem\CaptainFinancialDaily;
+
+use App\Service\CaptainFinancialSystem\CaptainFinancialSystemOne\CaptainFinancialSystemOneGetBalanceDetailsService;
+
+class CaptainFinancialSystemOneDailyService
+{
+    public function __construct(
+        private CaptainFinancialSystemOneGetBalanceDetailsService $captainFinancialSystemOneGetBalanceDetailsService
+    )
+    {
+    }
+
+    /**
+     * Get array which includes:
+     * basic captain financial amount (due), bonus, and amount for store
+     */
+    public function getDailyCaptainFinancialAmount(array $captainFinancialSystemDetail, int $captainProfileId, string $fromDate, string $toDate): array
+    {
+        return $this->captainFinancialSystemOneGetBalanceDetailsService->calculateCaptainDuesAndStoreCashAmountOnly($captainFinancialSystemDetail,
+            $captainProfileId, $fromDate, $toDate);
+    }
+}

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialSystemTwoDailyService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialDaily/CaptainFinancialSystemTwoDailyService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Service\CaptainFinancialSystem\CaptainFinancialDaily;
+
+use App\Service\CaptainFinancialSystem\CaptainFinancialSystemTwo\CaptainFinancialSystemTwoGetBalanceDetailsService;
+
+class CaptainFinancialSystemTwoDailyService
+{
+    public function __construct(
+        private CaptainFinancialSystemTwoGetBalanceDetailsService $captainFinancialSystemTwoGetBalanceDetailsService
+    )
+    {
+    }
+
+    /**
+     * Get array which includes:
+     * basic captain financial amount (due), bonus, and amount for store
+     */
+    public function getDailyCaptainFinancialAmount(array $captainFinancialSystemDetail, int $captainProfileId, string $fromDate, string $toDate): array
+    {
+        return $this->captainFinancialSystemTwoGetBalanceDetailsService->calculateCaptainDuesAndStoreCashAmountOnly($captainFinancialSystemDetail,
+            $captainProfileId, $fromDate, $toDate);
+    }
+}

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemOneGetBalanceDetailsService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemOneGetBalanceDetailsService.php
@@ -4,18 +4,24 @@ namespace App\Service\CaptainFinancialSystem\CaptainFinancialSystemOne;
 
 use App\AutoMapping;
 use App\Constant\CaptainFinancialSystem\CaptainFinancialSystem;
+use App\Constant\CaptainFinancialSystem\CaptainFinancialSystemOne\CaptainFinancialSystemOneWorkDayConstant;
 use App\Response\CaptainFinancialSystem\CaptainFinancialSystemAccordingToCountOfHoursBalanceDetailResponse;
+use App\Service\DateFactory\DateFactoryService;
 
 class CaptainFinancialSystemOneGetBalanceDetailsService
 {
     public function __construct(
         private AutoMapping $autoMapping,
         private CaptainFinancialSystemOneOrderGetService $captainFinancialSystemOneOrderGetService,
-        private CaptainFinancialSystemStoreCashAmountGetService $captainFinancialSystemStoreCashAmountGetService
+        private CaptainFinancialSystemStoreCashAmountGetService $captainFinancialSystemStoreCashAmountGetService,
+        private DateFactoryService $dateFactoryService
     )
     {
     }
 
+    /**
+     * Get the count of delivered orders by specific captain and among specific date
+     */
     public function getDeliveredOrdersCountByCaptainProfileIdAndBetweenTwoDates(int $captainProfileId, string $fromDate, string $toDate): int
     {
         $countOrdersResult = $this->captainFinancialSystemOneOrderGetService->getDeliveredOrdersCountByCaptainProfileIdAndBetweenTwoDates($captainProfileId,
@@ -28,6 +34,9 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return 0;
     }
 
+    /**
+     * Get the count of delivered orders which overdue the 19 kilometer by specific captain and among specific date
+     */
     public function getOverdueDeliveredOrdersByCaptainProfileIdAndBetweenTwoDates(int $captainId, string $fromDate, string $toDate): int
     {
         $overdueOrdersResult = $this->captainFinancialSystemOneOrderGetService->getOverdueDeliveredOrdersByCaptainProfileIdAndBetweenTwoDates($captainId, $fromDate, $toDate);
@@ -39,14 +48,18 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return 0;
     }
 
-    // Get the dues of unpaid cash orders (for group of orders)
+    /**
+     * Get the count of unpaid cash delivered orders by specific captain and among specific date
+     */
     public function getUnPaidCashOrdersDuesByCaptainProfileIdAndDuringSpecificTime(int $captainProfileId, string $fromDate, string $toDate): int
     {
         return (int) $this->captainFinancialSystemStoreCashAmountGetService->getUnPaidCashOrdersDuesByCaptainProfileIdAndDuringSpecificTime($captainProfileId,
             $fromDate, $toDate);
     }
 
-    // Get count of orders without distance and delivered by specific captain during specific time
+    /**
+     * Get the count of delivered orders which have no distance by specific captain and among specific date
+     */
     public function getOrdersWithoutDistanceCountByCaptainProfileIdOnSpecificDate(int $captainProfileId, string $fromDate, string $toDate): int
     {
         $result = $this->captainFinancialSystemOneOrderGetService->getOrdersWithoutDistanceCountByCaptainProfileIdOnSpecificDate($captainProfileId,
@@ -59,6 +72,9 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return 0;
     }
 
+    /**
+     * Get the count of cancelled orders and related to a specific captain and among specific date
+     */
     public function getCancelledOrdersCountByCaptainProfileIdAndBetweenTwoDates(int $captainProfileId, string $fromDate, string $toDate): int
     {
         $countOrdersResult = $this->captainFinancialSystemOneOrderGetService->getCancelledOrdersCountByCaptainProfileIdAndBetweenTwoDates($captainProfileId,
@@ -71,6 +87,9 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return 0;
     }
 
+    /**
+     * Get the count of cancelled orders which overdue the 19 Kilometer and related to a specific captain and among specific date
+     */
     public function getOverdueCancelledOrdersByCaptainProfileIdAndBetweenTwoDates(int $captainId, string $fromDate, string $toDate): int
     {
         $overdueOrdersResult = $this->captainFinancialSystemOneOrderGetService->getOverdueCancelledOrdersByCaptainProfileIdAndBetweenTwoDates($captainId, $fromDate, $toDate);
@@ -82,7 +101,9 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return 0;
     }
 
-    // Get count of orders without distance and delivered by specific captain during specific time
+    /**
+     * Get count of orders without distance and delivered by specific captain during specific time
+     */
     public function getCancelledOrdersWithoutDistanceCountByCaptainProfileIdOnSpecificDate(int $captainProfileId, string $fromDate, string $toDate): int
     {
         $result = $this->captainFinancialSystemOneOrderGetService->getCancelledOrdersWithoutDistanceCountByCaptainProfileIdOnSpecificDate($captainProfileId,
@@ -95,7 +116,10 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return 0;
     }
 
-    // To prepare the financial details for the captain
+    /**
+     * Calculate captain financial due according to the first financial system, and
+     * Get  array which include financial details for captain
+     */
     public function calculateCaptainDues(array $financialSystemDetail, int $captainProfileId, array $date, int $countWorkdays): array
     {
         //get the count of delivered orders by captain
@@ -127,7 +151,10 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return $financialSystemDetail;
     }
 
-    //If the captain works 25 days he gets the monthly salary, if he works less than 25 days the captain gets the daily salary
+    /**
+     * The core function which responsible for the calculation of the captain financial due according to specific parameters
+     * If the captain works 25 days he gets the monthly salary, if he works less than 25 days the captain gets the daily salary
+     */
     public function financialDuesCalculator(int $countWorkdays, float $countOrdersCompleted, float $countOrdersMaxFromNineteen, float $compensationForEveryOrder, float $salary): float
     {
         if ($countWorkdays >= 25) {
@@ -140,7 +167,9 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return round((($countOrdersCompleted + $countOrdersMaxFromNineteen) * $compensationForEveryOrder ) + ($dailySalary * $countWorkdays), 2);
     }
 
-    // This function retrieve and initialize necessary fields for captain financial dues calculation
+    /**
+     * This function retrieve and initialize necessary fields for captain financial dues calculation
+     */
     public function initializeNecessaryFieldsForDuesCalculation(int $captainProfileId, array $datesArray, float $sumPayments, array $response): array
     {
         //get Count Orders
@@ -172,6 +201,11 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
         return $response;
     }
 
+    /**
+     * Calculate captain financial due according to the first financial system, and
+     * Get object of type CaptainFinancialSystemAccordingToCountOfHoursBalanceDetailResponse
+     * which include financial details
+     */
     public function getBalanceDetails(array $financialSystemDetail, int $captainProfileId, float $sumPayments, array $datesArray, int $countWorkdays): CaptainFinancialSystemAccordingToCountOfHoursBalanceDetailResponse
     {
         $financialSystemDetail = $this->initializeNecessaryFieldsForDuesCalculation($captainProfileId, $datesArray, $sumPayments,
@@ -192,5 +226,52 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
 
         return $this->autoMapping->map('array', CaptainFinancialSystemAccordingToCountOfHoursBalanceDetailResponse::class,
             $financialSystemDetail);
+    }
+
+    /**
+     * Get days count between two dates (each one of type string)
+     */
+    public function getDaysCountBetweenTwoDatesOfTypeString(string $fromDate, string $toDate): int
+    {
+        $daysCountResult = $this->dateFactoryService->getDaysCountBetweenTwoDatesOfTypeString($fromDate, $toDate);
+
+        if ($daysCountResult === false) {
+            return CaptainFinancialSystemOneWorkDayConstant::ZERO_WORK_DAY_COUNT_CONST;
+        }
+
+        return $daysCountResult;
+    }
+
+    /**
+     * Get array which includes:
+     * basic captain financial amount (due), bonus, and amount for store
+     */
+    public function calculateCaptainDuesAndStoreCashAmountOnly(array $captainFinancialSystemDetail, int $captainProfileId, string $fromDate, string $toDate): array
+    {
+        $financialAccountDetails = [];
+
+        $financialAccountDetails['basicFinancialAmount'] = 0.0;
+        $financialAccountDetails['bounce'] = 0.0;
+        $financialAccountDetails['amountForStore'] = 0.0;
+
+        $financialAccountDetails['amountForStore'] = $this->getUnPaidCashOrdersDuesByCaptainProfileIdAndDuringSpecificTime($captainProfileId,
+            $fromDate, $toDate);
+
+        $ordersCount = (float) $this->getDeliveredOrdersCountByCaptainProfileIdAndBetweenTwoDates($captainProfileId,
+                $fromDate, $toDate) +
+            ((float) $this->getCancelledOrdersCountByCaptainProfileIdAndBetweenTwoDates($captainProfileId, $fromDate, $toDate)
+                / CaptainFinancialSystem::CANCELLED_ORDER_DIVISION_FACTOR_CONST);
+
+        $ordersMaxFromNineteenCount = (float) $this->getOverdueDeliveredOrdersByCaptainProfileIdAndBetweenTwoDates($captainProfileId,
+                $fromDate, $toDate) +
+            ((float) $this->getOverdueCancelledOrdersByCaptainProfileIdAndBetweenTwoDates($captainProfileId, $fromDate, $toDate)
+                / CaptainFinancialSystem::CANCELLED_ORDER_DIVISION_FACTOR_CONST);
+
+        $workDaysCount = $this->getDaysCountBetweenTwoDatesOfTypeString($fromDate, $toDate);
+
+        $financialAccountDetails['basicFinancialAmount'] = $this->financialDuesCalculator($workDaysCount, $ordersCount,
+            $ordersMaxFromNineteenCount, $captainFinancialSystemDetail['compensationForEveryOrder'], $captainFinancialSystemDetail['salary']);
+
+        return $financialAccountDetails;
     }
 }

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemOneGetBalanceDetailsService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemOneGetBalanceDetailsService.php
@@ -49,7 +49,7 @@ class CaptainFinancialSystemOneGetBalanceDetailsService
     }
 
     /**
-     * Get the count of unpaid cash delivered orders by specific captain and among specific date
+     * Get the sum of unpaid cash and delivered orders amount (for store) by specific captain and among specific date
      */
     public function getUnPaidCashOrdersDuesByCaptainProfileIdAndDuringSpecificTime(int $captainProfileId, string $fromDate, string $toDate): int
     {

--- a/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemStoreCashAmountGetService.php
+++ b/backend/src/Service/CaptainFinancialSystem/CaptainFinancialSystemOne/CaptainFinancialSystemStoreCashAmountGetService.php
@@ -12,7 +12,9 @@ class CaptainFinancialSystemStoreCashAmountGetService
     {
     }
 
-    // Get the dues of unpaid cash orders (for group of orders)
+    /**
+     * Get the sum of unpaid cash and delivered orders amount (for store) by specific captain and among specific date
+     */
     public function getUnPaidCashOrdersDuesByCaptainProfileIdAndDuringSpecificTime(int $captainProfileId, string $fromDate, string $toDate): string
     {
         return $this->storeOwnerDuesFromCashOrdersService->getUnPaidCashOrdersDuesByCaptainAndDuringSpecificTime($captainProfileId,

--- a/backend/src/Service/DateFactory/DateFactoryService.php
+++ b/backend/src/Service/DateFactory/DateFactoryService.php
@@ -120,8 +120,13 @@ class DateFactoryService
         return DateTime::createFromInterface($dateTime);
     }
 
-    public function getStringDateOnlyFromDateTimeInterface(DateTimeInterface $dateTime): string
+//    public function getStringDateOnlyFromDateTimeInterface(DateTimeInterface $dateTime): string
+//    {
+//        return (DateTime::createFromInterface($dateTime)->format('Y-m-d 00:00:00'));
+//    }
+
+    public function getDaysCountBetweenTwoDatesOfTypeString(string $fromDate, string $toDate): bool|int
     {
-        return (DateTime::createFromInterface($dateTime)->format('Y-m-d 00:00:00'));
+        return (new DateTime($fromDate))->diff(new DateTime($toDate))->days;
     }
 }

--- a/backend/src/Service/StoreOwnerDuesFromCashOrders/StoreOwnerDuesFromCashOrdersService.php
+++ b/backend/src/Service/StoreOwnerDuesFromCashOrders/StoreOwnerDuesFromCashOrdersService.php
@@ -65,7 +65,9 @@ class StoreOwnerDuesFromCashOrdersService
         return $this->storeOwnerDuesFromCashOrdersManager->getStoreOwnerDuesFromCashOrdersByStoreOwnerId($storeOwnerId);
     }
 
-    // Get the dues of unpaid cash orders (for group of orders)
+    /**
+     * Get the sum of unpaid cash and delivered orders amount (for store) by specific captain and among specific date
+     */
     public function getUnPaidCashOrdersDuesByCaptainAndDuringSpecificTime(int $captainId, string $fromDate, string $toDate): string
     {
         $result = $this->storeOwnerDuesFromCashOrdersManager->getUnPaidCashOrdersDuesByCaptainAndDuringSpecificTime($captainId, $fromDate, $toDate);

--- a/backend/src/Service/Subscription/SubscriptionService.php
+++ b/backend/src/Service/Subscription/SubscriptionService.php
@@ -365,6 +365,7 @@ class SubscriptionService
     public function canCreateOrder(int $storeOwnerId): CanCreateOrderResponse|string
     {
         $storeStatus = $this->storeOwnerProfileService->checkStoreStatus($storeOwnerId);
+
         if($storeStatus === StoreProfileConstant::STORE_OWNER_PROFILE_INACTIVE_STATUS) {
             return $storeStatus;
         }


### PR DESCRIPTION
- calculate captain daily amount for financial system one had been set.
- calculate captain daily amount for financial system two had been set.
- cancreateorder API response had been updated.
- delete captain account by admin/super admin had been fixed.