### PR TITLE
DA-FB-unkowun-store-profile-when-add-paymaent-to-store

### DIFF
--- a/dashboard/lib/module_orders/ui/screens/order_cash_store_screen.dart
+++ b/dashboard/lib/module_orders/ui/screens/order_cash_store_screen.dart
@@ -333,8 +333,7 @@ class OrdersCashStoreScreenState extends State<OrdersCashStoreScreen> {
                                                   ?.toIso8601String(),
                                               toDate: ordersFilter.toDate
                                                   ?.toIso8601String(),
-                                              storeId: StoresHiveHelper()
-                                                  .getCurrentStoreID(),
+                                              storeId: int.tryParse(ordersFilter.storeId ?? '0'),
                                               amount: num.tryParse(
                                                       _amount.text.trim()) ??
                                                   0,


### PR DESCRIPTION
- fix bug unkowun store profile when add paymaent to store
take store ID from the order directly instead of cached value