### PR TITLE
Dev backend

### DIFF
--- a/backend/src/Controller/Admin/Order/AdminOrderController.php
+++ b/backend/src/Controller/Admin/Order/AdminOrderController.php
@@ -126,9 +126,10 @@ class AdminOrderController extends BaseController
 
     /**
      * admin: get specific order by id
-     * @Route("orderbyidforadmin/{id}", name="getSpecificOrderByIdForAdmin", methods={"GET"})
+     * @Route("orderbyidforadmin/{id}/{timeZone}", name="getSpecificOrderByIdForAdmin", methods={"GET"})
      * @IsGranted("ROLE_ADMIN")
      * @param int $id
+     * @param string|null $timeZone
      * @return JsonResponse
      *
      * @OA\Tag(name="Order")
@@ -154,9 +155,9 @@ class AdminOrderController extends BaseController
      *
      * @Security(name="Bearer")
      */
-    public function getSpecificOrderByIdForAdmin(int $id): JsonResponse
+    public function getSpecificOrderByIdForAdmin(int $id, ?string $timeZone = null): JsonResponse
     {
-        $result = $this->adminOrderService->getSpecificOrderByIdForAdmin($id);
+        $result = $this->adminOrderService->getSpecificOrderByIdForAdmin($id, $timeZone);
 
         return $this->response($result, self::FETCH);
     }
@@ -306,10 +307,11 @@ class AdminOrderController extends BaseController
 
     /**
      * admin: Get pending, hidden, and not delivered orders for admin.
-     * @Route("orderpending/{externalOrder}/{externalCompanyId}", name="getPendingOrdersForAdmin", methods={"GET"})
+     * @Route("orderpending/{externalOrder}/{externalCompanyId}/{timeZone}", name="getPendingOrdersForAdmin", methods={"GET"})
      * @IsGranted("ROLE_ADMIN")
      * @param int $externalOrder
      * @param int $externalCompanyId
+     * @param string|null $timeZone
      * @return JsonResponse
      * *
      * @OA\Tag(name="Order")
@@ -354,7 +356,7 @@ class AdminOrderController extends BaseController
      *
      * @Security(name="Bearer")
      */
-    public function getPendingOrdersForAdmin(int $externalOrder = 0, int $externalCompanyId = 0): JsonResponse
+    public function getPendingOrdersForAdmin(int $externalOrder = 0, int $externalCompanyId = 0, ?string $timeZone = null): JsonResponse
     {
         $response = $this->adminOrderService->getPendingOrdersForAdmin($this->getUserId(), $externalOrder, $externalCompanyId);
         

--- a/backend/src/Controller/Admin/OrderLog/AdminOrderLogController.php
+++ b/backend/src/Controller/Admin/OrderLog/AdminOrderLogController.php
@@ -17,19 +17,19 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class AdminOrderLogController extends BaseController
 {
-    private AdminOrderLogService $adminOrderLogService;
-
-    public function __construct(SerializerInterface $serializer, AdminOrderLogService $adminOrderLogService)
+    public function __construct(
+        SerializerInterface $serializer,
+        private AdminOrderLogService $adminOrderLogService)
     {
         parent::__construct($serializer);
-        $this->adminOrderLogService = $adminOrderLogService;
     }
 
     /**
      * admin: get order logs by order id for admin
-     * @Route("orderlogsbyorderidforadmin/{orderId}", name="fetchOrderLogsByOrderIdForAdmin", methods={"GET"})
+     * @Route("orderlogsbyorderidforadmin/{orderId}/{timeZone}", name="fetchOrderLogsByOrderIdForAdmin", methods={"GET"})
      * @IsGranted("ROLE_ADMIN")
      * @param int $orderId
+     * @param string|null $timeZone
      * @return JsonResponse
      *
      * @OA\Tag(name="Order Log")
@@ -57,9 +57,9 @@ class AdminOrderLogController extends BaseController
      *
      * @Security(name="Bearer")
      */
-    public function filterStoreOrdersByAdmin(int $orderId): JsonResponse
+    public function filterStoreOrdersByAdmin(int $orderId, ?string $timeZone = null): JsonResponse
     {
-        $result = $this->adminOrderLogService->getOrderLogsByOrderIdForAdmin($orderId);
+        $result = $this->adminOrderLogService->getOrderLogsByOrderIdForAdmin($orderId, $timeZone);
 
         return $this->response($result, self::FETCH);
     }

--- a/backend/src/Response/Admin/Order/OrderPendingResponse.php
+++ b/backend/src/Response/Admin/Order/OrderPendingResponse.php
@@ -45,15 +45,9 @@ class OrderPendingResponse
 
     public int $isHide;
 
-    /**
-     * @var string|null
-     */
-    public $captainName;
+    public ?string $captainName;
 
-    /**
-     * @var int|null
-     */
-    public $captainProfileId;
+    public ?int $captainProfileId;
 
     /**
      * @OA\Property(type="array", property="externalDeliveredOrders",

--- a/backend/src/Response/Admin/OrderLog/OrderLogByOrderIdGetForAdminResponse.php
+++ b/backend/src/Response/Admin/OrderLog/OrderLogByOrderIdGetForAdminResponse.php
@@ -16,46 +16,25 @@ class OrderLogByOrderIdGetForAdminResponse
 
     public \DateTime $createdAt;
 
-    /**
-     * @var string|int
-     */
-    public $createdBy;
+    public string|int $createdBy;
 
     public int $createdByUserType;
 
-    /**
-     * @var bool|null
-     */
-    public $isCaptainArrivedConfirmation;
+    public ?bool $isCaptainArrivedConfirmation;
 
     public int $storeOwnerBranchId;
 
     public int $storeOwnerProfileId;
 
-    /**
-     * @var null|int
-     */
-    public $captainProfileId;
+    public ?int $captainProfileId;
 
-    /**
-     * @var null|int
-     */
-    public $supplierProfileId;
+    public ?int $supplierProfileId;
 
-    /**
-     * @var null|int
-     */
-    public $isHide;
+    public ?int $isHide;
 
-    /**
-     * @var bool|int
-     */
-    public $orderIsMain;
+    public int|bool $orderIsMain;
 
-    /**
-     * @var int|null
-     */
-    public $primaryOrderId;
+    public ?int $primaryOrderId;
 
     /**
      * @OA\Property(type="array", property="images",

--- a/backend/src/Service/Admin/OrderLog/AdminOrderLogService.php
+++ b/backend/src/Service/Admin/OrderLog/AdminOrderLogService.php
@@ -10,19 +10,20 @@ use App\Service\FileUpload\UploadFileHelperService;
 
 class AdminOrderLogService
 {
-    private AutoMapping $autoMapping;
-    private OrderLogManager $orderLogManager;
-    private UploadFileHelperService $uploadFileHelperService;
-
-    public function __construct(AutoMapping $autoMapping, OrderLogManager $orderLogManager, UploadFileHelperService $uploadFileHelperService)
+    public function __construct(
+        private AutoMapping $autoMapping,
+        private OrderLogManager $orderLogManager,
+        private UploadFileHelperService $uploadFileHelperService
+    )
     {
-        $this->autoMapping = $autoMapping;
-        $this->orderLogManager = $orderLogManager;
-        $this->uploadFileHelperService = $uploadFileHelperService;
     }
 
-    public function getOrderLogsByOrderIdForAdmin(int $orderId): array
+    public function getOrderLogsByOrderIdForAdmin(int $orderId, ?string $timeZone = null): array
     {
+        if (($timeZone) && ($timeZone !== "")) {
+            $timeZone = str_replace("-", "/", $timeZone);
+        }
+
         $response = [];
 
         $orderLogs = $this->orderLogManager->getOrderLogsByOrderIdForAdmin($orderId);
@@ -34,6 +35,10 @@ class AdminOrderLogService
                 $value['images'] = $this->uploadFileHelperService->getImageParams($value['imagePath']);
 
                 $response[$key] = $this->autoMapping->map('array', OrderLogByOrderIdGetForAdminResponse::class, $value);
+
+                if ($response[$key]->createdAt) {
+                    $response[$key]->createdAt->setTimeZone(new \DateTimeZone($timeZone ? : 'Asia/Riyadh'));
+                }
             }
         }
 


### PR DESCRIPTION
- default timezone used in orderlogsbyorderidforadmin API.
- default timezone had been used in filterexternallydeliveredordersbyadmin, orderbyidforadmin/{id}/{timeZone}, and in orderpending/{externalOrder}/{externalCompanyId}/{timeZone}.